### PR TITLE
Change resize_to_data to only resize to the height of the genes datalayer to avoid unceasing growth

### DIFF
--- a/pheget/static/js/phewas_scatter.js
+++ b/pheget/static/js/phewas_scatter.js
@@ -100,17 +100,17 @@ LocusZoom.ScaleFunctions.add('effect_direction', function(parameters, input) {
     return null;
 });
 
-// Redefine the `resize_to_data` button to set the text to "Show All Genes" (and no other changes).
-// Delete this once LocusZoom allows configuring the text via the layout.
+// Redefine the `resize_to_data` button to resize only for the genes datalayer (and not the variant vertical line)
 LocusZoom.Dashboard.Components.set('resize_to_data', function(layout) {
     LocusZoom.Dashboard.Component.apply(this, arguments);
     this.update = function() {
         if (this.button) { return this; }
         this.button = new LocusZoom.Dashboard.Component.Button(this)
             .setColor(layout.color).setHtml('Show All Genes')
-            .setTitle('Automatically resize this panel to fit the data its currently showing')
+            .setTitle('Automatically resize this panel to show all the genes')
             .setOnclick(function() {
-                this.parent_panel.scaleHeightToData();
+                const genes_datalayer_height = this.parent_panel.data_layers.genes.getAbsoluteDataHeight();
+                this.parent_panel.scaleHeightToData(genes_datalayer_height);
                 this.update();
             }.bind(this));
         this.button.show();


### PR DESCRIPTION
Currently, every time you click "Show All Genes" the genes panel gets taller.

This has been the case ever since Alan's change that made the `variant` vertical line's height update to its panel's height on each render.  

Inside Alan's overridden `LocusZoom.DataLayers.add('orthogonal_line_varpos', function(layout) {`, I can change his line
```
panel[y_range][0] = panel.layout.height;
```
to 
```
panel[y_range][0] = panel.layout.height - panel.layout.margin.top - panel.layout.margin.bottom;
```
in which case the growth slows to only 8px per click.  Perhaps that's how it should work anyways.

Changing that line to 
```
panel[y_range][0] = panel.layout.height - panel.layout.margin.top - panel.layout.margin.bottom - 8;
```
stops the growth.  I don't know where those 8px are coming from.

Should the `resize_to_data` dashboard component allow a layout parameter `watch_only_datalayer_id: "genes"`?