### PR TITLE
Feature/table links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ For the prototype, source data will live in the folder `data/`. Really large fil
 To change settings specific to an individual machine (such as the data directory), edit the contents of `.env` 
 in the root directory of your project. A `.env-sample` file is provided as a template.
 
+For University of Michigan internal development, files can be found at the following locations:
+
+Tutorial videos: /net/amd/amkwong/media/
+Data files: /net/amd/amkwong/FIVEx/data/
+
+Tutorial videos should be copied or linked to the `media/` directory, and 
+data files should be copied or linked to the `data/` directory.
 
 ### Running the development server
 Make sure to activate your virtualenv at the start of every new terminal session: `$ source venv/bin/activate` 

--- a/fivex/api/__init__.py
+++ b/fivex/api/__init__.py
@@ -147,46 +147,53 @@ def gene_data_for_region_table(gene_id: str):
     """
     source = model.get_gene_data_table(gene_id.split(".")[0])
     data = []
-    with gzip.open(source) as f:
-        for line in f:
-            (
-                chromosome,
-                position,
-                ref_allele,
-                alt_allele,
-                tissue,
-                pip_cluster,
-                spip,
-                pip,
-                pval_nominal,
-                beta,
-                stderr_beta,
-            ) = (line.decode("utf-8").rstrip("\n").split("\t"))
-            chromosome = chromosome.replace("chr", "")
-            position = int(position)
-            pip_cluster = int(pip_cluster)
-            spip = float(spip)
-            pip = float(pip)
-            pval_nominal = float(pval_nominal)
-            if pval_nominal > 0:
-                log_pvalue = -math.log10(pval_nominal)
-            else:
-                log_pvalue = math.inf
-            beta = float(beta)
-            stderr_beta = float(stderr_beta)
-            tempDict = {
-                "chromosome": chromosome,
-                "position": position,
-                "ref_allele": ref_allele,
-                "alt_allele": alt_allele,
-                "tissue": tissue,
-                "pip_cluster": pip_cluster,
-                "spip": spip,
-                "pip": pip,
-                "log_pvalue": log_pvalue,
-                "beta": beta,
-                "stderr_beta": stderr_beta,
-            }
-            data.append(tempDict)
+    try:
+        with gzip.open(source) as f:
+            for line in f:
+                (
+                    chromosome,
+                    position,
+                    ref_allele,
+                    alt_allele,
+                    tissue,
+                    pip_cluster,
+                    spip,
+                    pip,
+                    pval_nominal,
+                    beta,
+                    stderr_beta,
+                ) = (line.decode("utf-8").rstrip("\n").split("\t"))
+                chromosome = chromosome.replace("chr", "")
+                position = int(position)
+                pip_cluster = int(pip_cluster)
+                spip = float(spip)
+                pip = float(pip)
+                pval_nominal = float(pval_nominal)
+                if pval_nominal > 0:
+                    log_pvalue = -math.log10(pval_nominal)
+                else:
+                    log_pvalue = math.inf
+                beta = float(beta)
+                stderr_beta = float(stderr_beta)
+                tempDict = {
+                    "chromosome": chromosome,
+                    "position": position,
+                    "ref_allele": ref_allele,
+                    "alt_allele": alt_allele,
+                    "tissue": tissue,
+                    "pip_cluster": pip_cluster,
+                    "spip": spip,
+                    "pip": pip,
+                    "log_pvalue": log_pvalue,
+                    "beta": beta,
+                    "stderr_beta": stderr_beta,
+                }
+                data.append(tempDict)
+    # Not being able to find a file is normal:
+    # Sometimes the listed gene has no variants with PIP > 1e-5 (the filtering criteria),
+    # in which case the corresponding gene-specific PIP file will not exist.
+    # When this happens, FIVEx should simply return an empty results json object to the page.
+    except FileNotFoundError:
+        pass
     results = {"data": data}
     return jsonify(results)

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,9 @@
       <router-link :to="{ name: 'about' }">
         About
       </router-link> -
+      <router-link :to="{ name: 'tutorial' }">
+        Tutorial
+      </router-link> -
       <a href="https://github.com/statgen/fivex">Contribute</a>
     </footer>
   </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,7 @@ import '@/assets/common.css';
 
 import About from '@/views/About.vue';
 import Home from '@/views/Home.vue';
+import Tutorial from '@/views/Tutorial.vue';
 
 Vue.use(BootstrapVue);
 Vue.use(VueRouter);
@@ -37,6 +38,12 @@ const routes = [
         name: 'about',
         component: About,
         meta: { title: 'About' },
+    },
+    {
+        path: '/tutorial/',
+        name: 'tutorial',
+        component: Tutorial,
+        meta: { title: 'Tutorial' },
     },
     {
         path: '/variant/:variant/',

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -409,9 +409,17 @@ export const TABLE_BASE_COLUMNS = [
         title: 'Gene',
         field: 'symbol',
         headerFilter: true,
-        formatter(cell) {
-            return `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`;
-        },
+        // formatter: 'link',
+        // formatterParams: {
+        //     label: (cell) => `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`,
+        //     url: (cell) => {
+        //         const data = cell.getRow().getData();
+        //         data.symbol data.tissue
+        //     }
+        // },
+        // formatter(cell) {
+        //     return `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`;
+        // },
     },
     { title: 'Tissue', field: 'tissue', headerFilter: true },
     { title: 'System', field: 'system', headerFilter: true },
@@ -429,7 +437,15 @@ export const TABLE_BASE_COLUMNS = [
 
 export const REGION_TABLE_BASE_COLUMNS = [
     { title: 'Chr', field: 'chromosome', headerFilter: false },
-    { title: 'Position', field: 'position', headerFilter: false },
+    { title: 'Position', field: 'position', headerFilter: false,
+        formatter: 'link', 
+        formatterParams: {
+            url: (cell) => {
+                const data = cell.getRow().getData();
+                const base = `/variant/${data.chromosome}_${data.position}`;
+                return base;
+            },
+        }},
     { title: 'Ref', field: 'ref_allele', headerFilter: false },
     { title: 'Alt', field: 'alt_allele', headerFilter: false },
     { title: 'Tissue', field: 'tissue', headerFilter: true },

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -404,17 +404,13 @@ export function tabulator_tooltip_maker(cell) {
     return e.innerText; // shows what's in the HTML (from `formatter`) instead of just `cell.getValue()`
 }
 
-// Old formatter
-// formatter(cell) {
-//     return `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`;
-// },
 export const TABLE_BASE_COLUMNS = [
     {   title: 'Gene',
         field: 'symbol',
         headerFilter: true,
-        formatter: 'link',
-        formatterParams: {
-            label: (cell) => `${cell.getValue()} (${cell.getData().gene_id})`,
+        formatter: 'link',  // Links from single variant view to a region view plot by using the chromosome, gene, and tissue
+        formatterParams: {  // FIX: display the label as italicized (will need to convert formatter to 'html' instead of 'link')
+            label: (cell) => `${cell.getValue()} (${cell.getData().gene_id})`,  
             url: (cell) => {
                 const data = cell.getRow().getData();
                 const base = `/region?chrom=${data.chromosome}&gene_id=${data.gene_id}&tissue=${data.tissue}`;
@@ -437,7 +433,7 @@ export const TABLE_BASE_COLUMNS = [
 
 export const REGION_TABLE_BASE_COLUMNS = [
     { title: 'Chr', field: 'chromosome', headerFilter: false },
-    { title: 'Position', field: 'position', headerFilter: false,
+    { title: 'Position', field: 'position', headerFilter: false,  // Links from region view to a single variant view plot by using chromosome and position
         formatter: 'link', 
         formatterParams: {
             url: (cell) => {

--- a/src/util/variant-helpers.js
+++ b/src/util/variant-helpers.js
@@ -404,23 +404,23 @@ export function tabulator_tooltip_maker(cell) {
     return e.innerText; // shows what's in the HTML (from `formatter`) instead of just `cell.getValue()`
 }
 
+// Old formatter
+// formatter(cell) {
+//     return `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`;
+// },
 export const TABLE_BASE_COLUMNS = [
-    {
-        title: 'Gene',
+    {   title: 'Gene',
         field: 'symbol',
         headerFilter: true,
-        // formatter: 'link',
-        // formatterParams: {
-        //     label: (cell) => `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`,
-        //     url: (cell) => {
-        //         const data = cell.getRow().getData();
-        //         data.symbol data.tissue
-        //     }
-        // },
-        // formatter(cell) {
-        //     return `<i>${cell.getValue()} (${cell.getData().gene_id}</i>)`;
-        // },
-    },
+        formatter: 'link',
+        formatterParams: {
+            label: (cell) => `${cell.getValue()} (${cell.getData().gene_id})`,
+            url: (cell) => {
+                const data = cell.getRow().getData();
+                const base = `/region?chrom=${data.chromosome}&gene_id=${data.gene_id}&tissue=${data.tissue}`;
+                return base;
+            },
+        }},
     { title: 'Tissue', field: 'tissue', headerFilter: true },
     { title: 'System', field: 'system', headerFilter: true },
     {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -51,6 +51,14 @@
                     query: {chrom: '2', start: 20501429, end: 21544073,
                             tissue: 'Esophagus_Gastroesophageal_Junction', gene_id: 'ENSG00000084674' }}"
             ><i>APOB</i></router-link></b>
+          <br>
+          First time?
+          <router-link
+            :to="{name: 'tutorial'} "
+          >
+            <b>View the tutorial here</b>
+          </router-link>
+          to see what FIVEx can do
         </div>
       </div>
     </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,7 +17,7 @@
               :to="{name: 'variant', params: {variant: '2_21044589'}}"
             >chr2:21044589</router-link>
             &bull;
-            Rsid:
+            rsID:
             <router-link
               :to="{name: 'variant', params: {variant: '1_109274968'}}"
             >rs12740374</router-link>

--- a/src/views/Tutorial.vue
+++ b/src/views/Tutorial.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-sm-12">
+        <h1>Tutorial</h1>
+        <p>
+          <video controls src="../../media/FIVEx_tutorial_1.mp4" type="video/mp4">
+           Your browser does not support the HTML5 Video element. Here is a <a href="media/FIVEx_tutorial_1.mp4">link</a> instead.
+          </video>
+        </p>
+        <p>
+          <video controls src="../../media/FIVEx_tutorial_2.mp4" type="video/mp4">
+           Your browser does not support the HTML5 Video element.
+          </video>
+        </p>
+        <p>
+          <video controls src="../../media/FIVEx_tutorial_3.mp4" type="video/mp4">
+           Your browser does not support the HTML5 Video element.
+          </video>
+        </p>
+        <p>
+          <video controls src="../../media/FIVEx_tutorial_4.mp4" type="video/mp4">
+           Your browser does not support the HTML5 Video element.
+          </video>
+        </p>
+        <p>
+          <video controls src="../../media/FIVEx_tutorial_5.mp4" type="video/mp4">
+           Your browser does not support the HTML5 Video element.
+          </video>
+        </p>
+        <p>
+          <video controls src="../../media/FIVEx_tutorial_6.mp4" type="video/mp4">
+           Your browser does not support the HTML5 Video element.
+          </video>
+        </p>
+        <p><small>&copy; {{ (new Date()).getFullYear() }} - The University of Michigan, Center for Statistical Genetics</small></p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+    name: 'tutorial',
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/src/views/Tutorial.vue
+++ b/src/views/Tutorial.vue
@@ -4,33 +4,45 @@
       <div class="col-sm-12">
         <h1>Tutorial</h1>
         <p>
-          <video controls src="../../media/FIVEx_tutorial_1.mp4" type="video/mp4">
-           Your browser does not support the HTML5 Video element. Here is a <a href="media/FIVEx_tutorial_1.mp4">link</a> instead.
+          <video controls
+           src="../../media/FIVEx_tutorial_1.mp4"
+           type="video/mp4">
+            Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls src="../../media/FIVEx_tutorial_2.mp4" type="video/mp4">
-           Your browser does not support the HTML5 Video element.
+          <video controls
+           src="../../media/FIVEx_tutorial_2.mp4"
+           type="video/mp4">
+            Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls src="../../media/FIVEx_tutorial_3.mp4" type="video/mp4">
-           Your browser does not support the HTML5 Video element.
+          <video controls
+           src="../../media/FIVEx_tutorial_3.mp4"
+           type="video/mp4">
+            Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls src="../../media/FIVEx_tutorial_4.mp4" type="video/mp4">
-           Your browser does not support the HTML5 Video element.
+          <video controls
+           src="../../media/FIVEx_tutorial_4.mp4"
+           type="video/mp4">
+            Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls src="../../media/FIVEx_tutorial_5.mp4" type="video/mp4">
-           Your browser does not support the HTML5 Video element.
+          <video controls
+           src="../../media/FIVEx_tutorial_5.mp4"
+           type="video/mp4">
+            Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls src="../../media/FIVEx_tutorial_6.mp4" type="video/mp4">
-           Your browser does not support the HTML5 Video element.
+          <video controls
+           src="../../media/FIVEx_tutorial_6.mp4"
+           type="video/mp4">
+            Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p><small>&copy; {{ (new Date()).getFullYear() }} - The University of Michigan, Center for Statistical Genetics</small></p>
@@ -41,7 +53,7 @@
 
 <script>
 export default {
-    name: 'tutorial',
+    name: 'Tutorial',
 };
 </script>
 

--- a/src/views/Tutorial.vue
+++ b/src/views/Tutorial.vue
@@ -5,49 +5,55 @@
         <h1>Tutorial</h1>
         <p>
           <video
-           controls
-           src="../../media/FIVEx_tutorial_1.mp4"
-           type="video/mp4">
+            controls
+            src="../../media/FIVEx_tutorial_1.mp4"
+            type="video/mp4"
+          >
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
           <video
-           controls
-           src="../../media/FIVEx_tutorial_2.mp4"
-           type="video/mp4">
+            controls
+            src="../../media/FIVEx_tutorial_2.mp4"
+            type="video/mp4"
+          >
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
           <video
-           controls
-           src="../../media/FIVEx_tutorial_3.mp4"
-           type="video/mp4">
+            controls
+            src="../../media/FIVEx_tutorial_3.mp4"
+            type="video/mp4"
+          >
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
           <video
-           controls
-           src="../../media/FIVEx_tutorial_4.mp4"
-           type="video/mp4">
+            controls
+            src="../../media/FIVEx_tutorial_4.mp4"
+            type="video/mp4"
+          >
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
           <video
-           controls
-           src="../../media/FIVEx_tutorial_5.mp4"
-           type="video/mp4">
+            controls
+            src="../../media/FIVEx_tutorial_5.mp4"
+            type="video/mp4"
+          >
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
           <video
-           controls
-           src="../../media/FIVEx_tutorial_6.mp4"
-           type="video/mp4">
+            controls
+            src="../../media/FIVEx_tutorial_6.mp4"
+            type="video/mp4"
+          >
             Your browser does not support the HTML5 Video element.
           </video>
         </p>

--- a/src/views/Tutorial.vue
+++ b/src/views/Tutorial.vue
@@ -4,42 +4,48 @@
       <div class="col-sm-12">
         <h1>Tutorial</h1>
         <p>
-          <video controls
+          <video
+           controls
            src="../../media/FIVEx_tutorial_1.mp4"
            type="video/mp4">
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls
+          <video
+           controls
            src="../../media/FIVEx_tutorial_2.mp4"
            type="video/mp4">
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls
+          <video
+           controls
            src="../../media/FIVEx_tutorial_3.mp4"
            type="video/mp4">
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls
+          <video
+           controls
            src="../../media/FIVEx_tutorial_4.mp4"
            type="video/mp4">
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls
+          <video
+           controls
            src="../../media/FIVEx_tutorial_5.mp4"
            type="video/mp4">
             Your browser does not support the HTML5 Video element.
           </video>
         </p>
         <p>
-          <video controls
+          <video
+           controls
            src="../../media/FIVEx_tutorial_6.mp4"
            type="video/mp4">
             Your browser does not support the HTML5 Video element.

--- a/src/views/Variant.vue
+++ b/src/views/Variant.vue
@@ -248,6 +248,7 @@ export default {
                     'phewas:log_pvalue', 'phewas:gene_id', 'phewas:tissue', 'phewas:system',
                     'phewas:symbol', 'phewas:beta', 'phewas:stderr_beta', 'phewas:pip',
                     'phewas:pip_cluster',
+                    'phewas:chromosome', // Added this so we can link from the table in our single variant view to a region view page (the linking url requires chromosome, gene, and tissue)
                 ],
                 (data) => {
                     // Data sent from locuszoom contains a prefix (phewas:). We'll remove that prefix before

--- a/util/create.UM.statgen.links.sh
+++ b/util/create.UM.statgen.links.sh
@@ -1,6 +1,1 @@
-ln -f -s -t ../data/ /net/amd/amkwong/browseQTL/all_chr/ensembl/Homo_sapiens.GRCh38.97.chr.gff3.gz
-ln -f -s -t ../data/ /net/amd/amkwong/browseQTL/all_chr/data/by_chromosome/chr*.All_Tissues.sorted.txt.gz*
-ln -f -s -t ../data/ /net/amd/amkwong/browseQTL/all_chr/ensembl/gene.symbol.pickle
-ln -f -s -t ../data/ /net/amd/amkwong/browseQTL/all_chr/ensembl/gene.chrom.pos.lookup.sqlite3.db
-ln -f -s -t ../data/ /net/amd/amkwong/browseQTL/all_chr/ensembl/ID.only.gff3.gz*
-ln -f -s -t ../data/ /net/amd/amkwong/browseQTL/all_chr/GTEx_v8_finemapping_DAPG.sqlite.db
+ln -f -s -t ../data /net/amd/amkwong/FIVEx/data/*


### PR DESCRIPTION
## Ticket
n/a

## Purpose
Minor feature updates, mostly for adding links inside the data tables:
- In single-variant view, links will bring users to a region view of the chosen gene
- In region view, links will bring users to single-variant view of the chosen variant

Updated instructions on where to find data files for University of Michigan internal developers

Added a more prominent link to the video tutorial on the home page

## How to test this
Click on links in both single variant and region view tables, making sure the destinations agree with what the user clicked

## Deployment / configuration notes
(none)
